### PR TITLE
 온보딩 마지막 버튼 텍스트 사라지는 이슈 수정

### DIFF
--- a/presentation/src/main/java/com/example/presentation/SplashActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/SplashActivity.kt
@@ -17,8 +17,8 @@ class SplashActivity : AppCompatActivity() {
         lifecycleScope.launch {
             delay(3000)
 
-            val isFirst = SharedPrefUtil.isFirstLaunch(this@SplashActivity)
-            val intent = if (!isFirst) {
+            val isFirst = SharedPrefUtil.getInstance(this@SplashActivity).isFirstLaunch()
+            val intent = if (isFirst) {
                 Intent(this@SplashActivity, OnboardingActivity::class.java)
             } else {
                 Intent(this@SplashActivity, MainActivity::class.java)

--- a/presentation/src/main/java/com/example/presentation/button/base/BaseButton.kt
+++ b/presentation/src/main/java/com/example/presentation/button/base/BaseButton.kt
@@ -100,12 +100,6 @@ abstract class BaseButton @JvmOverloads constructor(
         buttonTextView?.isPressed = pressed
     }
 
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        removeAllViews()
-        buttonTextView = null
-    }
-
     companion object {
         private const val INVALID_RES_ID = -1
         private const val INVALID_SIZE = -1f


### PR DESCRIPTION
## 📌 변경 사항
- [x] 버그 수정
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 기타 (문서, 스타일 변경 등)

## 📝 작업 내용
- 온보딩 마지막 화면에서 버튼 텍스트가 사라지던 문제 해결
- BaseButton의 onDetachedFromWindow()에서 removeAllViews() 호출을 제거하여, 텍스트뷰가 유지되도록 수정했습니다.

- SharedPrefUtil 정적 호출을 getInstance(context).isFirstLaunch() 형식으로 변경했었는데 이전 PR 및 커밋에서 빠져있어 추가했습니다


## 🔗 관련 이슈
Fixes #23

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/940bad97-07ce-4023-a187-e26b31ab4124



## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함을 확인했나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 리뷰어가 참고할 만한 추가 설명이 있나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 앱 시작 시 첫 실행 사용자를 올바르게 식별하여 온보딩 화면이 적절히 표시되도록 초기 실행 흐름을 수정했습니다.

- **Refactor**
  - 버튼 요소의 라이프사이클 처리를 개선하여 사용자 인터페이스의 일관성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->