### PR TITLE
나옹 디자인 시스템 - 슬라이딩 탭 토글 추가

### DIFF
--- a/presentation/src/main/java/com/example/presentation/tab/SlidingTabToggleView.kt
+++ b/presentation/src/main/java/com/example/presentation/tab/SlidingTabToggleView.kt
@@ -20,9 +20,6 @@ class SlidingTabToggleView @JvmOverloads constructor(
     private val binding: SlidingTabToggleViewBinding
     private var selectedTab: Tab = Tab.LOCATION
 
-    private var iconColorAnimator: ValueAnimator? = null
-    private var textColorAnimator: ValueAnimator? = null
-
     var onTabSelected: ((Tab) -> Unit)? = null
 
     enum class Tab {

--- a/presentation/src/main/java/com/example/presentation/tab/SlidingTabToggleView.kt
+++ b/presentation/src/main/java/com/example/presentation/tab/SlidingTabToggleView.kt
@@ -20,6 +20,9 @@ class SlidingTabToggleView @JvmOverloads constructor(
     private val binding: SlidingTabToggleViewBinding
     private var selectedTab: Tab = Tab.LOCATION
 
+    private var iconColorAnimator: ValueAnimator? = null
+    private var textColorAnimator: ValueAnimator? = null
+
     var onTabSelected: ((Tab) -> Unit)? = null
 
     enum class Tab {
@@ -159,4 +162,10 @@ class SlidingTabToggleView @JvmOverloads constructor(
     }
 
     fun getSelectedTab(): Tab = selectedTab
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        binding.viewSelectedTabOverlay.animate().cancel()
+    }
+
 }

--- a/presentation/src/main/java/com/example/presentation/tab/SlidingTabToggleView.kt
+++ b/presentation/src/main/java/com/example/presentation/tab/SlidingTabToggleView.kt
@@ -1,0 +1,162 @@
+package com.example.presentation.tab
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.example.presentation.R
+import com.example.presentation.databinding.SlidingTabToggleViewBinding
+
+class SlidingTabToggleView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : LinearLayout(context, attrs) {
+
+    private val binding: SlidingTabToggleViewBinding
+    private var selectedTab: Tab = Tab.LOCATION
+
+    var onTabSelected: ((Tab) -> Unit)? = null
+
+    enum class Tab {
+        LOCATION, TIME
+    }
+
+    init {
+        val inflater = LayoutInflater.from(context)
+        binding = SlidingTabToggleViewBinding.inflate(inflater, this, true)
+
+        binding.tabLocation.setOnClickListener { selectTab(Tab.LOCATION) }
+        binding.tabTime.setOnClickListener { selectTab(Tab.TIME) }
+
+        // 뷰 레이아웃 완료 후 초기 위치 설정
+        post {
+            val tabWidth = binding.tabContainer.width / 2
+
+            binding.viewSelectedTabOverlay.layoutParams =
+                binding.viewSelectedTabOverlay.layoutParams.apply {
+                    width = tabWidth
+                }
+            binding.viewSelectedTabOverlay.requestLayout()
+            selectTab(selectedTab, forceUpdate = true)
+        }
+
+    }
+
+    private fun selectTab(tab: Tab, forceUpdate: Boolean = false) {
+        if (!forceUpdate && selectedTab == tab) return
+        selectedTab = tab
+
+        when (tab) {
+            Tab.LOCATION -> {
+                updateTabUI(
+                    selectedIcon = binding.imageViewLocation,
+                    selectedText = binding.textViewLocation,
+                    unselectedIcon = binding.imageViewTime,
+                    unselectedText = binding.textViewTime
+                )
+            }
+
+            Tab.TIME -> {
+                updateTabUI(
+                    selectedIcon = binding.imageViewTime,
+                    selectedText = binding.textViewTime,
+                    unselectedIcon = binding.imageViewLocation,
+                    unselectedText = binding.textViewLocation
+                )
+            }
+        }
+
+        onTabSelected?.invoke(tab)
+        moveSelectedOverlay(tab, animate = !forceUpdate)
+    }
+
+
+    private fun moveSelectedOverlay(tab: Tab, animate: Boolean) {
+        val targetX = when (tab) {
+            Tab.LOCATION -> 0f
+            Tab.TIME -> binding.tabContainer.width / 2f
+        }
+
+        if (animate) {
+            binding.viewSelectedTabOverlay.animate()
+                .translationX(targetX)
+                .setDuration(220)
+                .setInterpolator(AccelerateDecelerateInterpolator())
+                .start()
+        } else {
+            binding.viewSelectedTabOverlay.translationX = targetX
+        }
+    }
+
+    private fun animateTextAndIconColor(
+        icon: ImageView,
+        text: TextView,
+        fromIconColor: Int,
+        toIconColor: Int,
+        fromTextColor: Int,
+        toTextColor: Int
+    ) {
+        val duration = 220L
+
+        ValueAnimator.ofArgb(fromIconColor, toIconColor).apply {
+            setDuration(duration)
+            addUpdateListener { animator ->
+                icon.setColorFilter(animator.animatedValue as Int)
+            }
+            start()
+        }
+
+        ValueAnimator.ofArgb(fromTextColor, toTextColor).apply {
+            setDuration(duration)
+            addUpdateListener { animator ->
+                text.setTextColor(animator.animatedValue as Int)
+            }
+            start()
+        }
+    }
+
+
+    private fun updateTabUI(
+        selectedIcon: ImageView,
+        selectedText: TextView,
+        unselectedIcon: ImageView,
+        unselectedText: TextView
+    ) {
+        val colorPrimary = ContextCompat.getColor(context, R.color.primary)
+        val colorBlack = ContextCompat.getColor(context, R.color.black)
+        val colorGray2 = ContextCompat.getColor(context, R.color.gray2)
+        val colorGray3 = ContextCompat.getColor(context, R.color.gray3)
+
+        // 선택된 쪽 부드럽게 강조
+        animateTextAndIconColor(
+            icon = selectedIcon,
+            text = selectedText,
+            fromIconColor = colorGray2,
+            toIconColor = colorPrimary,
+            fromTextColor = colorGray3,
+            toTextColor = colorBlack
+        )
+
+        // 선택 해제된 쪽 부드럽게 축소
+        animateTextAndIconColor(
+            icon = unselectedIcon,
+            text = unselectedText,
+            fromIconColor = colorPrimary,
+            toIconColor = colorGray2,
+            fromTextColor = colorBlack,
+            toTextColor = colorGray3
+        )
+    }
+
+
+    fun setSelectedTab(tab: Tab) {
+        selectTab(tab)
+    }
+
+    fun getSelectedTab(): Tab = selectedTab
+}

--- a/presentation/src/main/res/drawable/tab_container_background.xml
+++ b/presentation/src/main/res/drawable/tab_container_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/gray1" />
+    <corners android:radius="16dp" />
+</shape>

--- a/presentation/src/main/res/drawable/tab_selected_background.xml
+++ b/presentation/src/main/res/drawable/tab_selected_background.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="8dp" />
+</shape>

--- a/presentation/src/main/res/drawable/tab_unselected_background.xml
+++ b/presentation/src/main/res/drawable/tab_unselected_background.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <solid android:color="@android:color/transparent" />
+</shape>

--- a/presentation/src/main/res/layout/sliding_tab_toggle_view.xml
+++ b/presentation/src/main/res/layout/sliding_tab_toggle_view.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="56dp"
+    android:layout_margin="16dp"
+    android:background="@drawable/tab_container_background"
+    android:elevation="4dp"
+    android:padding="8dp">
+
+    <View
+        android:id="@+id/viewSelectedTabOverlay"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_gravity="start|center_vertical"
+        android:background="@drawable/tab_selected_background" />
+
+    <LinearLayout
+        android:id="@+id/tabContainer"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:id="@+id/tabLocation"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:baselineAligned="true"
+            android:baselineAlignedChildIndex="1"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/imageViewLocation"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_location"
+                app:tint="@color/primary" />
+
+            <TextView
+                android:id="@+id/textViewLocation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="-2dp"
+                android:text="위치"
+                android:textAppearance="@style/body16bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/tabTime"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:baselineAligned="true"
+            android:baselineAlignedChildIndex="1"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/imageViewTime"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_time"
+                app:tint="@color/primary" />
+
+            <TextView
+                android:id="@+id/textViewTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="-2dp"
+                android:text="시간"
+                android:textAppearance="@style/body16bold" />
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
## 📌 변경 사항
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 기타 (문서, 스타일 변경 등)

## 📝 작업 내용
- SlidingTabToggleView 커스텀 뷰 구현
  - 2개의 탭(위치, 시간)을 토글 형태로 선택 가능
  - 선택된 탭 아래에 흰색 배경 뷰가 슬라이딩되며 이동
  - 아이콘 및 텍스트 색상은 선택 상태에 따라 부드럽게 전환
- 선택 애니메이션 상세
  - 슬라이딩: 0.22초, ease-in-out
  - 색상 전환: ValueAnimator.ofArgb() 사용하여 동일 시간에 애니메이션 처리


## 🔗 관련 이슈
Fixes #25 



## 📸 스크린샷 (선택)

-  영상 녹화 시 기기 성능 이슈로 인해 프레임이 일부 저하되어 보일 수 있으나,
실제 환경에서는 애니메이션 전환이 부드럽게 구현되어 있습니다.

https://github.com/user-attachments/assets/9561a7d8-cadf-4101-a7aa-c440ffea5514

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함을 확인했나요?
- [ ] 관련 문서를 업데이트했나요?
- [x] 리뷰어가 참고할 만한 추가 설명이 있나요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 위치와 시간을 선택할 수 있는 슬라이딩 탭 토글 UI 컴포넌트가 추가되었습니다. 탭 전환 시 애니메이션 효과와 색상 변화가 적용되며, 선택된 탭이 시각적으로 강조됩니다.
  - 탭 선택 상태 변경 시 외부에서 알림을 받을 수 있는 콜백 기능이 제공됩니다.

- **스타일**
  - 탭 컨테이너 및 선택/비선택 상태의 탭에 적용되는 배경과 둥근 모서리 스타일이 추가되었습니다.

- **레이아웃**
  - 새로운 커스텀 탭 토글 뷰의 레이아웃이 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->