### PR TITLE
빌드 실패로 인해 gradle 8.9로 업그레이드 작업 진행

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Feb 22 12:40:21 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 📌 변경 사항
- [x] 버그 수정
- [ ] 기능 추가
- [ ] 리팩토링
- [ ] 기타 (문서, 스타일 변경 등)

### 📌 재현 방법
1. 기존 상태에서 Android Studio에서 Sync 또는 빌드 실행
2. Gradle 캐시 내 metadata.bin 파일 관련 오류 발생
3. Gradle 버전을 업그레이드하여 해결됨

### 🛠️ 시도한 해결 방법
- `.gradle` 폴더 전체 삭제 → 실패
- 특정 transform 캐시 삭제 → 실패
- Gradle 버전 업그레이드(8.7 → **8.9**) 후 해결됨
- 이후 다시 8.7로 변경했지만 동일에러 발생

### 💡 원인 추정
Gradle 8.7에서 transforms-4 캐시 내 metadata.bin 파일이 손상되었을 때 fallback 처리가 제대로 되지 않아, 빌드 실패함.  
Gradle 8.9에서는 해당 문제를 더 유연하게 처리하여 해결된 것으로 보임.

## 🔗 관련 이슈
Fixes #30

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함을 확인했나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 리뷰어가 참고할 만한 추가 설명이 있나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Gradle 버전이 8.7에서 8.9로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->